### PR TITLE
Ignore MSYS2 NotFound exception silently

### DIFF
--- a/lib/ruby_installer.rb
+++ b/lib/ruby_installer.rb
@@ -128,7 +128,7 @@ module RubyInstaller
       require "fiddle"
       set_default_dll_directories_winapi rescue Fiddle::DLError
       # We silently ignore this error to allow Ruby installations without MSYS2.
-      path = mingw_bin_path rescue MsysNotFound
+      path = mingw_bin_path rescue nil
       add_dll_directory(path) if path
     end
 


### PR DESCRIPTION
Hi, I've found a strange behavior code which ignores MSYS2 installation.

The following path variable will set `MsysNotFound` class when not finding installed MSYS2.

```ruby
path = mingw_bin_path rescue MsysNotFound
```

Is this intended behavior?